### PR TITLE
4724: Update just-the-docs library to 0.8.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source "https://rubygems.org"
 
 gem "jekyll", "~> 4.3.3"
 gem "sass-embedded", "~> 1.69.5"
-gem "just-the-docs", "~> 0.7.0"
+gem "just-the-docs", "~> 0.8.1"
 gem "wdm", "~> 0.1.1" if Gem.win_platform?
 group :jekyll_plugins do
   gem "jekyll-feed"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -43,7 +43,7 @@ GEM
       jekyll (>= 3.8, < 5.0)
     jekyll-watch (2.2.1)
       listen (~> 3.0)
-    just-the-docs (0.7.0)
+    just-the-docs (0.8.1)
       jekyll (>= 3.8.5)
       jekyll-include-cache
       jekyll-seo-tag (>= 2.0)
@@ -83,7 +83,7 @@ DEPENDENCIES
   jekyll-archives
   jekyll-feed
   jekyll-seo-tag (~> 2.8.0)
-  just-the-docs (~> 0.7.0)
+  just-the-docs (~> 0.8.1)
   sass-embedded (~> 1.69.5)
 
 BUNDLED WITH


### PR DESCRIPTION
Updating because of the fixes. It does not fix the H1 issue.